### PR TITLE
Remove top-level function

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,8 +10,7 @@ const optipng = require("imagemin-optipng");
 const pngquant = require("imagemin-pngquant");
 const svgo = require("imagemin-svgo");
 
-module.exports = () => {
-  return {
+module.exports = {
     name: "netlify-plugin-image-optim",
 
     postBuild: async config => {
@@ -80,5 +79,4 @@ module.exports = () => {
         })
       );
     }
-  };
 };


### PR DESCRIPTION
This removes the top-level function of the plugin for simplication, since it is not currently used.