### PR TITLE
Rename `plugin.name`

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,8 +12,6 @@ const svgo = require("imagemin-svgo");
 
 module.exports = () => {
   return {
-    name: "netlify-plugin-image-optim",
-
     postBuild: async config => {
       const files = {};
       const glob = `${config.constants.BUILD_DIR}/**/*.{gif,jpg,jpeg,png,svg}`;


### PR DESCRIPTION
The `name` property in plugins has been removed. Plugins should now [use a `manifest.yml` instead](https://github.com/netlify/build#anatomy-of-a-plugin).