### PR TITLE
Fix npm keyword

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
   "keywords": [
     "image optimization",
     "netlify",
-    "netlify plugin"
+    "netlify-plugin"
   ]
 }


### PR DESCRIPTION
Small typo: the keyword in `package.json` is spelled `netlify-plugin`.