### PR TITLE
Add `bugs` field in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "type": "git",
     "url": "git+https://github.com/chrisdwheatley/netlify-plugin-image-optim.git"
   },
+  "bugs": {
+    "url": "https://github.com/chrisdwheatley/netlify-plugin-image-optim/issues"
+  },
   "dependencies": {
     "boxen": "^4.1.0",
     "chalk": "^2.4.2",


### PR DESCRIPTION
This adds a `bugs` field in `package.json`. This field is used by Netlify when reporting plugin errors.