### PR TITLE
Enable progressive on jpegtran

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ module.exports = {
       });
 
       const optimizedFiles = await imagemin([glob], {
-        plugins: [gifsicle(), optipng(), pngquant(), svgo(), jpegtran()]
+        plugins: [gifsicle(), optipng(), pngquant(), svgo(), jpegtran({progressive:true})]
       });
 
       optimizedFiles.map(file => {


### PR DESCRIPTION
This enables the progressive option on jpegtran. Should improve visual perception of download speed for processed jpegs and marginally reduce filesize with no loss of quality.